### PR TITLE
Fix avalanche parsing crash on 'treeline' elevation

### DIFF
--- a/custom_components/slovenian_weather_integration/arso_weather/avalanche_client.py
+++ b/custom_components/slovenian_weather_integration/arso_weather/avalanche_client.py
@@ -125,10 +125,12 @@ def _parse_danger_ratings(ratings: list[dict]) -> dict[str, Any]:
         elev = rating.get("elevation", {})
         if "lowerBound" in elev:
             danger_high = level
-            elevation = int(elev["lowerBound"])
+            bound = elev["lowerBound"]
+            elevation = int(bound) if str(bound).isdigit() else str(bound)
         elif "upperBound" in elev:
             danger_low = level
-            elevation = int(elev["upperBound"])
+            bound = elev["upperBound"]
+            elevation = int(bound) if str(bound).isdigit() else str(bound)
         else:
             danger_high = level
             danger_low = level


### PR DESCRIPTION
## Summary
- ARSO CAAMLv6 API vrača `"treeline"` kot nadmorsko višino v plazovnih podatkih
- `int("treeline")` povzroči `ValueError` in prepreči nalaganje config entry (npr. Ljubljana)
- Popravek: preveri ali je vrednost številka, sicer ohrani kot string

## Napaka
```
Config entry 'Ljubljana' for slovenian_weather_integration integration not ready yet: 
Error fetching avalanche data: invalid literal for int() with base 10: 'treeline'
```

## Test plan
- [ ] Preveri da se Ljubljana config entry uspešno naloži
- [ ] Preveri da avalanche senzorji delujejo z numeričnimi in tekstovnimi mejami
- [ ] Preveri da `elevation_boundary` atribut pravilno prikaže "treeline" ali številko

🤖 Generated with [Claude Code](https://claude.com/claude-code)