### PR TITLE
Fix sensor name spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Always enabled. Provides a `weather` entity and up to 44 sensor entities per loc
 |------------------|-----|------|-------------|
 | Višina oblakov | `cloud_base_text` | -- | All stations (forecast) |
 | Napovedan sneg | `accumulated_snow_mm` | mm | All stations (forecast) |
-| Napoveden dež | `accumulated_precipitation_mm` | mm | All stations (forecast) |
+| Napovedan dež | `accumulated_precipitation_mm` | mm | All stations (forecast) |
 
 **Note on entity IDs:** HA auto-generates entity IDs from the device name and sensor name. For example, with device "ARSO Weather Ljubljana" and sensor "Temperatura", the entity ID becomes `sensor.arso_weather_ljubljana_temperatura`. Sensor names are in Slovenian, so entity IDs contain Slovenian words.
 

--- a/custom_components/slovenian_weather_integration/sensor.py
+++ b/custom_components/slovenian_weather_integration/sensor.py
@@ -407,7 +407,7 @@ FORECAST_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     ),
     SensorEntityDescription(
         key="accumulated_precipitation_mm",
-        name="Napoveden dež",
+        name="Napovedan dež",
         native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
         device_class=SensorDeviceClass.PRECIPITATION,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
Rename "Napoveden dež" to "Napovedan dež"