### PR TITLE
Fix deprecated CONCENTRATION_* constants (UnitOfDensity)

### DIFF
--- a/custom_components/slovenian_weather_integration/manifest.json
+++ b/custom_components/slovenian_weather_integration/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/andrejs2/slovenian_weather_integration/issues",
   "requirements": [],
-  "version": "2.0.8"
+  "version": "2.0.9"
 }

--- a/custom_components/slovenian_weather_integration/sensor.py
+++ b/custom_components/slovenian_weather_integration/sensor.py
@@ -14,8 +14,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
     CONF_LOCATION,
     DEGREE,
     PERCENTAGE,
@@ -35,6 +33,21 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 import homeassistant.util.dt as dt_util
+
+# Air quality unit constants. `UnitOfDensity` only exists on HA >= 2026.7, where the
+# CONCENTRATION_* constants became deprecated (removal announced for HA 2027.8).
+# The deprecated import is reached only on older cores, which emit no warning for it.
+# Both branches yield the same unit strings, so entity units never change.
+try:
+    from homeassistant.const import UnitOfDensity
+
+    MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    MILLIGRAMS_PER_CUBIC_METER = UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER
+except ImportError:  # HA < 2026.7
+    from homeassistant.const import (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER as MILLIGRAMS_PER_CUBIC_METER,
+    )
 
 from .arso_weather.agrometeo_client import AGRO_STATIONS
 from .arso_weather.air_quality_client import AQ_STATIONS, EAQI_LABELS, compute_eaqi
@@ -543,7 +556,7 @@ AQ_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         key="pm10",
         name="PM10",
         device_class=SensorDeviceClass.PM10,
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
@@ -551,14 +564,14 @@ AQ_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
         key="pm2.5",
         name="PM2.5",
         device_class=SensorDeviceClass.PM25,
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
     SensorEntityDescription(
         key="o3",
         name="Ozon (O3)",
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:molecule",
         suggested_display_precision=1,
@@ -566,7 +579,7 @@ AQ_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="no2",
         name="Dušikov dioksid (NO2)",
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:molecule",
         suggested_display_precision=1,
@@ -574,7 +587,7 @@ AQ_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="so2",
         name="Žveplov dioksid (SO2)",
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:molecule",
         suggested_display_precision=1,
@@ -582,7 +595,7 @@ AQ_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="co",
         name="Ogljikov monoksid (CO)",
-        native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=MILLIGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:molecule-co",
         suggested_display_precision=2,


### PR DESCRIPTION
Closes #40

## Problem

Home Assistant logs deprecation warnings for the integration's air quality sensors:

> The deprecated constant CONCENTRATION_MICROGRAMS_PER_CUBIC_METER was used from slovenian_weather_integration. It will be removed in HA Core 2027.8. Use UnitOfDensity.MICROGRAMS_PER_CUBIC_METER instead.

The integration still works today, this is a warning, not an error but the constants will be **removed in HA Core 2027.8**, at which point the sensor platform would fail to load.

## Scope

Only `sensor.py` is affected:
- 6× `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` (PM10, PM2.5, O3, NO2, SO2)
- 1× `CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER` (CO)

All other deprecated constants currently listed in HA `const.py` were cross-checked against the whole integration, no other hits, and no hardcoded unit strings anywhere.

## Why not a plain rename

`UnitOfDensity` was only **introduced in HA 2026.7** (verified against HA core git tags: it does not exist in 2025.1.0–2026.6.x; the constants became warning-emitting `_DEPRECATED_*` in 2026.8). This integration supports **HA 2025.1.0+** (`hacs.json`), so an unconditional `from homeassistant.const import UnitOfDensity` would raise `ImportError` and break the integration for everyone on HA < 2026.7.

## Fix

Compatibility shim in `sensor.py`:

```python
try:
    from homeassistant.const import UnitOfDensity
    MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
    MILLIGRAMS_PER_CUBIC_METER = UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER
except ImportError:  # HA < 2026.7
    from homeassistant.const import (
        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as MICROGRAMS_PER_CUBIC_METER,
        CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER as MILLIGRAMS_PER_CUBIC_METER,
    )
```

The deprecated import is only reached on cores older than 2026.7, which do not emit the warning. Result: no warnings on new HA, no breakage on old HA. **Minimum HA version stays 2025.1.0.**

## No unit change

Both branches resolve to the exact unit strings each HA version produced before (verified by codepoint comparison via simulating both branches against stub `homeassistant.const` modules). Existing air quality entities, their units and long-term statistics are unaffected.

Also bumps version to 2.0.9.