### PR TITLE
Fix warnings sensor: read current level from time-filtered CAP blocks

### DIFF
--- a/SENSORS.md
+++ b/SENSORS.md
@@ -167,7 +167,7 @@ glavnem [README](README.md); spodaj je tip podatka.
 | Agrometeo               | Temperatura tal (5/10/30 cm), min temp., evapotranspiracija, vodna bilanca   | 🟢 Meritev + 🔵 napoved |
 | Kakovost zraka          | EAQI + PM10, PM2.5, O₃, NO₂, SO₂, CO                                         | 🟢 Meritev              |
 | UTCI (toplotni občutek) | Univerzalni toplotni indeks po urah                                          | 🔵 Napoved              |
-| Vremenska opozorila     | Pregled aktivnih opozoril + binarni senzorji po tipu                         | 🔵 Napoved/opozorilo    |
+| Vremenska opozorila     | Trenutno veljavna opozorila (atribut `napovedana_opozorila` za prihodnja) + binarni senzorji po tipu | 🔵 Napoved/opozorilo    |
 | Snežni plazovi          | EAWS bilten po regijah (stopnja nevarnosti ...)                              | 🔵 Napoved/opozorilo    |
 
 ***

--- a/custom_components/slovenian_weather_integration/arso_weather/warnings_client.py
+++ b/custom_components/slovenian_weather_integration/arso_weather/warnings_client.py
@@ -1,14 +1,20 @@
 """Client for fetching weather warnings from ARSO.
 
-Data source: meteo.arso.gov.si — ATOM feed + CAP XML per warning type.
+Data source: meteo.arso.gov.si — combined CAP XML per region.
 5 warning regions, 10 warning types, 4 severity levels.
+
+The combined CAP file (``warning_{region}_latest_CAP.xml``) contains one
+``<info>`` block per warning type AND per validity period, covering ~5 days
+ahead. The currently valid level for a type is therefore NOT the first block
+(nor the ATOM feed title, which does not reflect the currently valid period)
+but the block whose onset/expires interval contains the current time.
 """
 
 from __future__ import annotations
 
 import logging
-import re
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
@@ -17,13 +23,9 @@ from .client import ArsoApiError
 
 _LOGGER = logging.getLogger(__name__)
 
-ATOM_URL = (
-    "https://meteo.arso.gov.si/uploads/probase/www/warning/text/sl/"
-    "warning_{region}_latest.atom"
-)
 CAP_URL = (
     "https://meteo.arso.gov.si/uploads/probase/www/warning/text/sl/"
-    "warning_{type}_{region}_latest_CAP.xml"
+    "warning_{region}_latest_CAP.xml"
 )
 
 # Warning regions
@@ -57,9 +59,34 @@ SEVERITY_LEVELS: dict[int, dict[str, str]] = {
     4: {"color": "rdeča", "text": "Zelo velika ogroženost", "en": "Extreme"},
 }
 
-# XML namespaces
-_NS_ATOM = {"atom": "http://www.w3.org/2005/Atom"}
-_NS_CAP = {"cap": "urn:oasis:names:tc:emergency:cap:1.2"}
+# CAP awareness_type parameter ("5; high-temperature") -> warning type code.
+# Numeric codes follow MeteoAlarm conventions; the text token is a fallback.
+_AWARENESS_TYPE_CODES: dict[str, str] = {
+    "1": "wind",
+    "2": "snow",
+    "3": "TS",
+    "5": "Tx",
+    "6": "Tn",
+    "7": "coastal",
+    "8": "forestFire",
+    "9": "avalanche",
+    "10": "rain",
+    "14": "ice",
+}
+_AWARENESS_TYPE_NAMES: dict[str, str] = {
+    "wind": "wind",
+    "snow-ice": "snow",
+    "thunderstorm": "TS",
+    "high-temperature": "Tx",
+    "low-temperature": "Tn",
+    "coastalevent": "coastal",
+    "forest-fire": "forestFire",
+    "avalanches": "avalanche",
+    "rain": "rain",
+    "ice": "ice",
+}
+
+_CAP = "{urn:oasis:names:tc:emergency:cap:1.2}"
 
 
 def region_from_coordinates(lat: float, lon: float) -> str:
@@ -95,146 +122,148 @@ def region_from_coordinates(lat: float, lon: float) -> str:
     return "SLOVENIA_MIDDLE"
 
 
-def _parse_level_from_title(title: str) -> int:
-    """Extract warning level (1-4) from ATOM entry title.
-
-    Title format: "Veter - neznatna ogroženost (Stopnja 1/4) - Slovenija / osrednja"
-    """
-    match = re.search(r"Stopnja\s+(\d)/4", title)
-    if match:
-        return int(match.group(1))
-    return 1
-
-
-def _parse_type_from_url(url: str) -> str | None:
-    """Extract warning type code from CAP URL.
-
-    URL: .../warning_wind_SLOVENIA_MIDDLE_latest_CAP.xml
-    """
-    match = re.search(r"warning_(\w+)_SLOVENIA", url)
-    if match:
-        return match.group(1)
-    return None
-
-
-def _parse_atom_feed(text: str) -> list[dict[str, Any]]:
-    """Parse ATOM feed into a list of warning summaries."""
+def _parse_dt(value: str | None) -> datetime | None:
+    """Parse a CAP timestamp ("2026-08-11T10:00:00+02:00") to aware datetime."""
+    if not value:
+        return None
     try:
-        root = ET.fromstring(text)
-    except ET.ParseError as err:
-        raise ArsoApiError(f"Failed to parse warnings ATOM: {err}") from err
-
-    warnings: list[dict[str, Any]] = []
-    for entry in root.findall("atom:entry", _NS_ATOM):
-        title_el = entry.find("atom:title", _NS_ATOM)
-        link_el = entry.find("atom:link", _NS_ATOM)
-        updated_el = entry.find("atom:updated", _NS_ATOM)
-
-        title = title_el.text if title_el is not None else ""
-        url = link_el.get("href", "") if link_el is not None else ""
-        updated = updated_el.text if updated_el is not None else None
-
-        warning_type = _parse_type_from_url(url)
-        level = _parse_level_from_title(title)
-
-        if warning_type:
-            warnings.append({
-                "type": warning_type,
-                "type_name": WARNING_TYPES.get(warning_type, warning_type),
-                "level": level,
-                "level_color": SEVERITY_LEVELS.get(level, {}).get("color", ""),
-                "level_text": SEVERITY_LEVELS.get(level, {}).get("text", ""),
-                "title": title,
-                "cap_url": url,
-                "updated": updated,
-            })
-
-    return warnings
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        # ARSO timestamps carry an offset; treat a missing one as UTC.
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
-def _parse_cap_xml(text: str) -> dict[str, Any]:
-    """Parse CAP XML for detailed warning info (Slovenian language)."""
-    try:
-        root = ET.fromstring(text)
-    except ET.ParseError as err:
-        raise ArsoApiError(f"Failed to parse CAP XML: {err}") from err
+def _parse_info_block(info: ET.Element) -> dict[str, Any] | None:
+    """Parse one Slovenian CAP <info> block into a warning period dict."""
+    lang = info.findtext(_CAP + "language")
+    if lang and not lang.startswith("sl"):
+        return None
 
-    result: dict[str, Any] = {
-        "sent": root.findtext("{urn:oasis:names:tc:emergency:cap:1.2}sent"),
+    warning_type: str | None = None
+    level: int | None = None
+    for param in info.findall(_CAP + "parameter"):
+        name = param.findtext(_CAP + "valueName")
+        value = param.findtext(_CAP + "value") or ""
+        parts = [p.strip() for p in value.split(";")]
+        if name == "awareness_type" and parts:
+            warning_type = _AWARENESS_TYPE_CODES.get(parts[0])
+            if warning_type is None and len(parts) > 1:
+                warning_type = _AWARENESS_TYPE_NAMES.get(parts[1].lower())
+        elif name == "awareness_level" and parts:
+            try:
+                level = int(parts[0])
+            except ValueError:
+                level = None
+
+    if warning_type is None or level is None:
+        _LOGGER.debug(
+            "Skipping CAP info block without awareness type/level: %s",
+            info.findtext(_CAP + "event"),
+        )
+        return None
+
+    onset = info.findtext(_CAP + "onset")
+    expires = info.findtext(_CAP + "expires")
+    return {
+        "type": warning_type,
+        "type_name": WARNING_TYPES.get(warning_type, warning_type),
+        "level": level,
+        "level_color": SEVERITY_LEVELS.get(level, {}).get("color", ""),
+        "level_text": SEVERITY_LEVELS.get(level, {}).get("text", ""),
+        "title": info.findtext(_CAP + "headline"),
+        "description": (info.findtext(_CAP + "description") or "").strip(),
+        "instruction": (info.findtext(_CAP + "instruction") or "").strip(),
+        "onset": onset,
+        "expires": expires,
+        "onset_dt": _parse_dt(onset),
+        "expires_dt": _parse_dt(expires),
+        "severity": info.findtext(_CAP + "severity"),
+        "urgency": info.findtext(_CAP + "urgency"),
+        "certainty": info.findtext(_CAP + "certainty"),
     }
 
-    # Find Slovenian info block
-    for info in root.findall("{urn:oasis:names:tc:emergency:cap:1.2}info"):
-        lang = info.findtext("{urn:oasis:names:tc:emergency:cap:1.2}language")
-        if lang and lang != "sl":
-            continue
 
-        result["event"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}event"
-        )
-        result["headline"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}headline"
-        )
-        result["description"] = (
-            info.findtext(
-                "{urn:oasis:names:tc:emergency:cap:1.2}description"
-            )
-            or ""
-        ).strip()
-        result["instruction"] = (
-            info.findtext(
-                "{urn:oasis:names:tc:emergency:cap:1.2}instruction"
-            )
-            or ""
-        ).strip()
-        result["severity"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}severity"
-        )
-        result["urgency"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}urgency"
-        )
-        result["certainty"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}certainty"
-        )
-        result["onset"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}onset"
-        )
-        result["expires"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}expires"
-        )
-        result["effective"] = info.findtext(
-            "{urn:oasis:names:tc:emergency:cap:1.2}effective"
-        )
+def _is_current(period: dict[str, Any], now: datetime) -> bool:
+    """Check whether a warning period is valid at ``now``.
 
-        # Extract parameters
-        for param in info.findall(
-            "{urn:oasis:names:tc:emergency:cap:1.2}parameter"
+    A missing onset/expires bound is treated as open-ended.
+    """
+    onset = period["onset_dt"]
+    expires = period["expires_dt"]
+    if onset is not None and now < onset:
+        return False
+    if expires is not None and now > expires:
+        return False
+    return True
+
+
+def parse_warnings_cap(
+    text: str, now: datetime | None = None
+) -> dict[str, Any]:
+    """Parse a combined CAP XML into current + upcoming warnings.
+
+    Returns ``{"updated": ..., "warnings": [...], "upcoming_warnings": [...]}``
+    where ``warnings`` holds the currently valid period per type (level >= 2
+    only) and ``upcoming_warnings`` the future periods with level >= 2.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as err:
+        raise ArsoApiError(f"Failed to parse warnings CAP XML: {err}") from err
+
+    periods = [
+        parsed
+        for info in root.findall(_CAP + "info")
+        if (parsed := _parse_info_block(info)) is not None
+    ]
+    if not periods:
+        raise ArsoApiError("Warnings CAP XML contains no usable info blocks")
+
+    sent = root.findtext(_CAP + "sent")
+
+    current: dict[str, dict[str, Any]] = {}
+    upcoming: list[dict[str, Any]] = []
+    for period in periods:
+        period["updated"] = sent
+        if _is_current(period, now):
+            # Keep the most severe period if several overlap "now".
+            existing = current.get(period["type"])
+            if existing is None or period["level"] > existing["level"]:
+                current[period["type"]] = period
+        elif (
+            period["level"] >= 2
+            and period["onset_dt"] is not None
+            and period["onset_dt"] > now
         ):
-            name = param.findtext(
-                "{urn:oasis:names:tc:emergency:cap:1.2}valueName"
-            )
-            value = param.findtext(
-                "{urn:oasis:names:tc:emergency:cap:1.2}value"
-            )
-            if name == "awareness_level" and value:
-                # "1; green; Minor" → extract level number
-                parts = value.split(";")
-                if parts:
-                    try:
-                        result["awareness_level"] = int(parts[0].strip())
-                    except ValueError:
-                        pass
+            upcoming.append(period)
 
-        break  # Only need Slovenian info
+    warnings = [w for w in current.values() if w["level"] >= 2]
+    warnings.sort(key=lambda w: w["level"], reverse=True)
+    upcoming.sort(key=lambda w: w["onset_dt"])
 
-    return result
+    # Internal datetime helpers must not leak into coordinator data.
+    for period in periods:
+        period.pop("onset_dt", None)
+        period.pop("expires_dt", None)
+
+    return {
+        "updated": sent,
+        "warnings": warnings,
+        "upcoming_warnings": upcoming,
+    }
 
 
 async def fetch_warnings(
     session: aiohttp.ClientSession,
     region: str,
 ) -> dict[str, Any]:
-    """Fetch all weather warnings for a region.
+    """Fetch all weather warnings for a region (single CAP request).
 
     Args:
         session: aiohttp client session
@@ -245,80 +274,38 @@ async def fetch_warnings(
         {
             "region": "SLOVENIA_MIDDLE",
             "region_name": "Osrednja Slovenija",
-            "updated": "2026-03-12T09:09:44+01:00",
+            "updated": "2026-08-11T15:25:00+02:00",
             "warnings": [
                 {
-                    "type": "wind",
-                    "type_name": "Veter",
+                    "type": "Tx",
+                    "type_name": "Visoka temperatura",
                     "level": 3,
                     "level_color": "oranžna",
                     "level_text": "Velika ogroženost",
-                    "title": "Veter - velika ogroženost...",
-                    "description": "Pričakujemo...",
-                    "instruction": "Priporočamo...",
-                    "onset": "...",
-                    "expires": "...",
+                    "title": "Visoka temperatura - velika ogroženost...",
+                    "description": "...",
+                    "instruction": "...",
+                    "onset": "2026-08-11T10:00:00+02:00",
+                    "expires": "2026-08-11T19:59:00+02:00",
                     "updated": "...",
                 },
             ],
+            "upcoming_warnings": [...],  # same shape, future periods
         }
     """
-    # Step 1: Fetch ATOM feed (1 request for all types)
-    atom_url = ATOM_URL.format(region=region)
+    cap_url = CAP_URL.format(region=region)
     try:
-        async with session.get(atom_url) as response:
+        async with session.get(cap_url) as response:
             response.raise_for_status()
-            atom_text = await response.text()
+            cap_text = await response.text()
     except aiohttp.ClientResponseError as err:
         raise ArsoApiError(
-            f"HTTP {err.status} fetching warnings ATOM: {err.message}"
+            f"HTTP {err.status} fetching warnings CAP: {err.message}"
         ) from err
     except aiohttp.ClientError as err:
         raise ArsoApiError(f"Failed to fetch warnings: {err}") from err
 
-    # Parse ATOM
-    try:
-        atom_root = ET.fromstring(atom_text)
-    except ET.ParseError as err:
-        raise ArsoApiError(f"Failed to parse warnings ATOM: {err}") from err
-
-    feed_updated = atom_root.findtext("{http://www.w3.org/2005/Atom}updated")
-    atom_warnings = _parse_atom_feed(atom_text)
-
-    # Step 2: For warnings with level >= 2, fetch CAP XML for details
-    result_warnings: list[dict[str, Any]] = []
-    for warning in atom_warnings:
-        if warning["level"] >= 2:
-            # Fetch detailed CAP XML
-            cap_url = warning.get("cap_url", "")
-            if cap_url:
-                try:
-                    async with session.get(cap_url) as resp:
-                        resp.raise_for_status()
-                        cap_text = await resp.text()
-                    cap_data = _parse_cap_xml(cap_text)
-                    warning.update({
-                        "description": cap_data.get("description", ""),
-                        "instruction": cap_data.get("instruction", ""),
-                        "onset": cap_data.get("onset"),
-                        "expires": cap_data.get("expires"),
-                        "severity": cap_data.get("severity"),
-                        "urgency": cap_data.get("urgency"),
-                        "certainty": cap_data.get("certainty"),
-                    })
-                except Exception:
-                    _LOGGER.debug(
-                        "Failed to fetch CAP for %s", warning["type"],
-                        exc_info=True,
-                    )
-            result_warnings.append(warning)
-
-    # Sort by level descending (most severe first)
-    result_warnings.sort(key=lambda w: w["level"], reverse=True)
-
-    return {
-        "region": region,
-        "region_name": WARNING_REGIONS.get(region, region),
-        "updated": feed_updated,
-        "warnings": result_warnings,
-    }
+    result = parse_warnings_cap(cap_text)
+    result["region"] = region
+    result["region_name"] = WARNING_REGIONS.get(region, region)
+    return result

--- a/custom_components/slovenian_weather_integration/coordinator.py
+++ b/custom_components/slovenian_weather_integration/coordinator.py
@@ -560,7 +560,7 @@ class AvalancheCoordinator(DataUpdateCoordinator[dict]):
 
 
 class WarningsCoordinator(DataUpdateCoordinator[dict]):
-    """Manage fetching ARSO weather warnings (ATOM feed + CAP XML).
+    """Manage fetching ARSO weather warnings (combined CAP XML).
 
     Auto-detects the warning region from the weather coordinator's
     location coordinates.
@@ -571,7 +571,7 @@ class WarningsCoordinator(DataUpdateCoordinator[dict]):
             "region": "SLOVENIA_MIDDLE",
             "region_name": "Osrednja Slovenija",
             "updated": "2026-03-12T09:09:44+01:00",
-            "warnings": [
+            "warnings": [  # currently valid periods, level >= 2
                 {
                     "type": "wind",
                     "type_name": "Veter",
@@ -585,6 +585,7 @@ class WarningsCoordinator(DataUpdateCoordinator[dict]):
                     "expires": "...",
                 },
             ],
+            "upcoming_warnings": [...],  # future periods, level >= 2
         }
     """
 

--- a/custom_components/slovenian_weather_integration/sensor.py
+++ b/custom_components/slovenian_weather_integration/sensor.py
@@ -1992,9 +1992,10 @@ class ArsoWarningsOverviewSensor(
 ):
     """Overview sensor for weather warnings.
 
-    State: "Ni opozoril" when no active warnings (level >= 2),
+    State: "Ni opozoril" when no currently valid warnings (level >= 2),
            or summary like "Veter (oranžna), Dež (rumena)".
-    Attributes: region, full warning details, updated timestamp.
+    Attributes: region, full details of current warnings, upcoming
+    (future-period) warnings, updated timestamp.
     """
 
     _attr_has_entity_name = True
@@ -2065,6 +2066,20 @@ class ArsoWarningsOverviewSensor(
                     "posodobljeno": w.get("updated"),
                 }
                 for w in active
+            ]
+        upcoming = data.get("upcoming_warnings") or []
+        if upcoming:
+            attrs["napovedana_opozorila"] = [
+                {
+                    "tip": w.get("type"),
+                    "tip_ime": w.get("type_name"),
+                    "stopnja": w.get("level"),
+                    "barva": w.get("level_color"),
+                    "opis_stopnje": w.get("level_text"),
+                    "veljavnost_od": w.get("onset"),
+                    "veljavnost_do": w.get("expires"),
+                }
+                for w in upcoming
             ]
         return attrs
 


### PR DESCRIPTION
## Povzetek

Popravek napačnih stopenj vremenskih opozoril, ki jih je 11. 8. 2026 po e-pošti uporabnik integracije: senzor je dopoldan kazal rumeno opozorilo za nevihte, ko je bila stopnja dejansko še zelena (rumeni blok je začel veljati šele ob 15:00), ob 15:00 pa rumeno namesto oranžne za visoko temperaturo.

## Vzrok (potrjeno v živo 11. 8. ob 15:30)

- Stopnja se je brala z regexom »Stopnja X/4« iz **naslova ATOM vnosa**, ki pa ne odraža trenutno veljavne stopnje (ob 15:31 je za visoko temperaturo pisal 2/4, medtem ko je bil trenutno veljavni CAP blok 3/4 — oranžna).
- CAP datoteka vsebuje **vse časovne bloke za ~5 dni vnaprej** (en `<info>` blok na tip IN obdobje veljavnosti), `_parse_cap_xml` pa je vzel samo prvi slovenski blok in ignoriral `onset`/`expires` — prihodnja opozorila so bila prikazana kot trenutno aktivna, dnevni prehodi stopnje pa so se zgodili šele ob ARSO-jevi ponovni objavi datoteke.

## Rešitev

- Bere se **kombinirani** `warning_{REGION}_latest_CAP.xml` — **1 HTTP zahteva na cikel namesto 1 ATOM + do 10 CAP** (pomembno zaradi rate limitinga na `meteo.arso.gov.si` pri 5-min intervalu).
- Trenutna stopnja za posamezen tip = blok, katerega interval `onset`–`expires` vsebuje trenutni čas; stopnja se bere iz parametra `awareness_level`, tip iz `awareness_type` (brez regexa po naslovu).
- Prehodi stopnje se zdaj uveljavijo v ≤ 5 min tudi, če ARSO datoteke ne objavi znova.
- Prihodnja obdobja s stopnjo ≥ 2 so izpostavljena kot `upcoming_warnings`; overview senzor jih pokaže v novem atributu `napovedana_opozorila` (od/do veljavnosti).
- Binarni senzorji nespremenjeni — berejo isti `warnings` seznam, ki zdaj vsebuje samo trenutno veljavna opozorila. Oblika slovarjev v `warnings` je nespremenjena, unique_id-ji nedotaknjeni.

## Test

Parser preverjen proti živi CAP datoteki (11. 8., osrednja Slovenija) pri 5 simuliranih časih:

| Čas | Prej (napačno) | Zdaj |
|---|---|---|
| 11. 8. 12:00 | nevihte rumene | Tx oranžna, požar oranžna; nevihte le med *napovedanimi* (od 15:00) |
| 11. 8. 15:30 | Tx rumena | **Tx oranžna**, požar oranžna, nevihte rumene |
| 11. 8. 21:00 | Tx še vedno prikazana | Tx pade na zeleno (blok se je iztekel ob 19:59), nevihte še rumene |
| 11. 8. 23:30 | — | samo požar oranžna |
| 12. 8. 12:00 | — | Tx rumena (jutrišnji blok) |