### PR TITLE
fix: forecast timeline out of order

### DIFF
--- a/custom_components/slovenian_weather_integration/arso_weather/client.py
+++ b/custom_components/slovenian_weather_integration/arso_weather/client.py
@@ -153,6 +153,7 @@ class ArsoWeather:
                 timeline: list[dict] = []
                 for day in data[key]["features"][0]["properties"]["days"]:
                     timeline.extend(day["timeline"])
+                timeline.sort(key=lambda item: item["valid"])
                 result[key] = timeline
                 _LOGGER.debug(
                     "Extracted %d entries for %s", len(timeline), key


### PR DESCRIPTION
Fixes #43 

Sorts the array of timelines by their "valid" key to prevent them being shown out of order due to an inconsistency in ARSO's API data. 